### PR TITLE
Start work on completion

### DIFF
--- a/complete.sh
+++ b/complete.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Source this file and then...
+
+# TODO: use after running the function
+compopt () {
+        #echo "Compopt run: $*" >&2
+        :
+}
+
+__completion_export_vars() {
+        local prog args
+        export COMP_LINE="$*"
+        prog="${COMP_LINE%% *}"
+        args="${COMP_LINE#* }"
+        # split completion line by space/newline
+        export COMP_WORDS=($COMP_LINE)
+        # "doubletap" expansion
+        export COMP_TYPE='9'
+        # always at the end of the line
+        export COMP_POINT=${#COMP_LINE}
+        # handle space at the end of string
+        if [[ "${COMP_LINE: -1}" = " " ]]; then
+                export COMP_CWORD=${#COMP_WORDS[@]}
+        else
+                export COMP_CWORD=$((${#COMP_WORDS[@]}-1))
+        fi
+}
+
+__completion_load() {
+        # try to load all possible completions
+        if [[ -n "$XDG_DATA_DIRS" ]]; then
+                while read -d: -r path; do
+                        for com_path in "$path/bash-completion/completions" "${path}/bash_completions.d"; do
+                                if [[ -d "$com_path" ]]; then
+                                        for file in "$com_path"/*; do
+                                                . "$file"
+                                        done
+                                fi
+                        done
+                # TODO: Maybe there's also usr/lib paths depending on OS
+                done <<< "/etc:${XDG_DATA_DIRS}"
+        fi
+}
+
+
+__completion_print() {
+        local prog args
+        __completion_export_vars "$*"
+        prog="${COMP_LINE%% *}"
+        args="${COMP_LINE#* }"
+        #echo "line is '$COMP_LINE' (${#COMP_LINE}) and prog is '$prog' (${#prog})" >&2
+        # If we're still on first word completion
+        if [[ "${#COMP_LINE}" -eq "${#prog}" ]]; then
+                #echo "complete first word" >&2
+                compgen -abc $prog | sort -u
+                return
+        fi
+
+        #example out: compgen -o bashdefault -o default -o nospace -F __git_wrap__git_main git s
+        comp_command="$(complete -p "$prog")"
+        if [[ -z "$comp_command" ]]; then
+                #echo no completions >&2
+                return
+        fi
+        is_func=false
+        for arg in $comp_command; do
+                # just run -F functions separately
+                if $is_func; then
+                        export MY_FUNCNAME="$arg"
+                        is_func=false
+                        echo eval "$arg" "$prog" "$COMP_CWORD" "${COMP_WORDS[$((${#COMP_WORDS[@]}-2))]}" >&2
+                        eval "$arg" "$prog" "$COMP_CWORD" "${COMP_WORDS[$((${#COMP_WORDS[@]}-2))]}"
+                        (IFS=$'\n'; echo "${COMPREPLY[*]}")
+                        # TODO: compgen filters with -X, prefix/suffix with -P and -S
+                        # E.g. compgen -P abc_ -F _myfunc
+                        # TODO: if empty result, use the -o options (if -o bashdefault or -o default)
+                        #exit
+                        return
+                fi
+                case "$arg" in
+                        # next argument is a function we wanna execute
+                        "-F" | "-C")
+                                is_func=true
+                                ;;
+                        # run with parameters
+                        "-u" | "-a" | "-v")
+                                compgen "$arg" "$args"
+                                # If we vomplete comp
+                                ;;
+                esac
+                #echo $arg
+        done
+        comp_command="${comp_command/complete/compgen}"
+        eval $comp_command
+}
+
+__completion_load

--- a/fanos.go
+++ b/fanos.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"errors"
 	"flag"
 	"io"
 	"log"
@@ -18,7 +19,7 @@ var (
 )
 
 type FANOSShell struct {
-	cmd *exec.Cmd
+	cmd    *exec.Cmd
 	socket *os.File
 
 	in, out, err *os.File
@@ -64,7 +65,8 @@ func (s *FANOSShell) Run(ctx context.Context, r io.Reader) error {
 
 	var buf bytes.Buffer
 	buf.WriteString("EVAL ")
-	_, err := io.Copy(&buf, r); if err != nil {
+	_, err := io.Copy(&buf, r)
+	if err != nil {
 		return err
 	}
 
@@ -94,4 +96,8 @@ func (s *FANOSShell) Run(ctx context.Context, r io.Reader) error {
 
 func (s *FANOSShell) Dir() string {
 	return ""
+}
+
+func (b *FANOSShell) Complete(ctx context.Context, cmd io.Reader) ([]string, error) {
+	return nil, errors.New("unimplemented")
 }

--- a/gosh.go
+++ b/gosh.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"io"
 	"log"
 	"mvdan.cc/sh/v3/interp"
@@ -39,4 +40,7 @@ func (s *GoShell) Run(ctx context.Context, r io.Reader) error {
 }
 func (s *GoShell) Dir() string {
 	return s.Runner.Dir
+}
+func (b *GoShell) Complete(ctx context.Context, cmd io.Reader) ([]string, error) {
+	return nil, errors.New("unimplemented")
 }

--- a/lib/inject_tcsetpgrp.c
+++ b/lib/inject_tcsetpgrp.c
@@ -32,6 +32,7 @@ static int stdout_fd = 1;
 void __attribute__((constructor)) inject_init() {
 	// Bash overwrites `getenv` with a version that looks for Bash variables.
 	// We can't use it, since Bash hasn't started at this point, so we scan __environ ourselves.
+  // TODO: On android we have to use 'environ' instead of '__environ'
 	for (int i = 0; __environ[i] != NULL; i++) {
 		if (strstr(__environ[i], "SETPGRP_FD=") == __environ[i]) { // substring is at the start
 			char* val = &(__environ[i][11]); // length of "SETPGRP_FD=" is 11

--- a/web/index.html
+++ b/web/index.html
@@ -14,6 +14,9 @@
             if (e.key === 'c' && e.ctrlKey) {
                 handleCancel(e);
             }
+            if (e.key === 'Tab' && !e.shiftKey) {
+                handleComplete(e);
+            }
         });
         document.getElementById("log").addEventListener("dblclick", function(e) {
             for (let el of e.composedPath().reverse()) {
@@ -32,6 +35,8 @@
         if (!command) {
             return
         }
+        const listEl = document.getElementById("completion-list");
+        listEl.innerHTML = '';
 
         let wrapper = createLogElement(command);
 
@@ -109,6 +114,64 @@
         });
     }
 
+    async function handleComplete(event) {
+        event.preventDefault();
+        const commandEl = document.getElementById("command");
+        const command = commandEl.value;
+        let words = command.split(" ")
+        const lastWord = words[words.length - 1]
+        if (!command) {
+            return
+        }
+        let listEl = document.getElementById("completion-list");
+        if (!listEl) {
+            return
+        }
+        // TODO: sometimes hangs
+        let curComp = document.getElementsByClassName("current-completion")[0];
+        if (curComp && curComp.innerHTML === lastWord) {
+            let nextComp = curComp.nextElementSibling;
+            if (nextComp == null) {
+                nextComp = listEl.firstElementChild;
+                if (nextComp == null) {
+                    return
+                }
+            }
+            curComp.classList.remove("current-completion");
+            nextComp.classList.add("current-completion");
+            words[words.length -1] = nextComp.innerHTML;
+            commandEl.value = words.join(" ");
+            return;
+        }
+
+        // Delete existing completions
+        listEl.innerHTML = '';
+        let json;
+        try {
+            const resp = await fetch("/complete", {
+                method: "POST",
+                body: command,
+            });
+            json = await resp.json();
+        } catch (error) {
+            console.error(error);
+            return
+        }
+
+        updateCompletionList(listEl, [ lastWord, ...json]);
+    }
+
+    function updateCompletionList(listEl, resp) {
+        for (const i in resp) {
+            let li = document.createElement("li");
+            li.classList.add("completion-element");
+            li.innerHTML = resp[i];
+            listEl.append(li);
+        }
+        // First element is what's in the prompt
+        listEl.firstElementChild.hidden = true;
+        listEl.firstElementChild.classList.add("current-completion")
+    }
     window.onload = main;
 </script>
 <link href="terminal.css" rel="stylesheet">
@@ -136,6 +199,9 @@
         height: 100px;
         width: 90%;
     }
+    .current-completion {
+      background-color: yellow;
+    }
 </style>
 </head>
 <body>
@@ -145,4 +211,5 @@
         <textarea name="command" id="command"></textarea>
         <button type="submit">Run</button>
     </form>
+    <div id="completion"><ul id="completion-list"></ul></div>
 </body>


### PR DESCRIPTION
I started implementing argument completion in a very dumb way. What I have done:
- Some refactoring
- Spit out completions for a command **arguments**
- An ugly `test` flag to test the completion function (I have to learn about `go` testing soon 😄 )
- adjusted the c file slightly. Maybe a problem with the ARM processor of my phone? Can probably be reverted, but I'll test this on my AMD64 first.

TODO:
 - [x] Fix the weird error when trying to use the webshell now (see below)
- [ ] finish completion of arguments
- [ ] implement completion for shell builtins/commands from the $PATH (or even better: find a was to properly ask the shell for completions. IDK how to do this and not sure I wanna read the readline code for this)
- [ ] remove the `test` flag - maybe replace with proper tests
- [ ] Write frontend for completion

Main reasons I'm already opening up a PR:
- What do you think of the refactoring? There's obviously more to do, but would you agree with them as a start to get it more into a state of being a framework?
- The shell access via web is kinda broken now. It always returns exit code 2 and I don't get why:
```
2023/07/02 17:06:27 bash.go:93: Parsed Message: {Done:true Pgid:0 Exit:2 Dir:/data/data/com.termux/files/home/git/web_shell}
2023/07/02 17:06:27 main.go:155: exit code: 2              2023/07/02 17:06:27 main.go:172: &{0x40000c2018 <nil> <nil> false true {0 0} true true false 0x5a4109d6c0}            2023/07/02 17:06:27 main.go:179: http: wrote more than the declared Content-Length
```
I will debug this when back on a computer, but just in case you see some mistake (if you take a look) :)