### PR TITLE
Change spelling of flags: to -oils and -oils_path

### DIFF
--- a/fanos.go
+++ b/fanos.go
@@ -15,7 +15,7 @@ import (
 )
 
 var (
-	fanosShellPath = flag.String("oil_path", "/usr/bin/oil", "Path to Oil shell interpreter")
+	fanosShellPath = flag.String("oils_path", "/usr/local/bin/osh", "Path to Oils interpreter (https://oils-for-unix.org/)")
 )
 
 type FANOSShell struct {

--- a/main.go
+++ b/main.go
@@ -36,7 +36,7 @@ var (
 	host = flag.String("host", "localhost", "Hostname at which to run the server")
 	port = flag.Int("port", 3000, "Port at which to run the server over HTTP")
 	gosh = flag.Bool("gosh", false, "Use the sh package instead of bash")
-	oil  = flag.Bool("oil", false, "Use oil instead of bash")
+	oils = flag.Bool("oils", false, "Use oil instead of bash")
 	fifo = flag.Bool("fifo", true, "Use named fifo instead of anonymous pipe")
 )
 
@@ -63,7 +63,7 @@ func main() {
 
 	if *gosh {
 		shell, err = NewGoShell()
-	} else if *oil {
+	} else if *oils {
 		shell, err = NewFANOSShell()
 	} else {
 		shell, err = NewBashShell()


### PR DESCRIPTION
Set the default path to /usr/local/bin/osh, since that's where it ends up after building the tarball.